### PR TITLE
Rework standard pending op

### DIFF
--- a/src/memdx/client.rs
+++ b/src/memdx/client.rs
@@ -339,7 +339,7 @@ mod tests {
         dbg!(&bootstrap_result.hello);
 
         let hello_result = bootstrap_result.hello.unwrap();
-        assert_eq!(9, hello_result.enabled_features.len());
+        assert_eq!(10, hello_result.enabled_features.len());
 
         let result: SetResponse = sync_unary_call(
             OpsCrud {

--- a/src/memdx/error.rs
+++ b/src/memdx/error.rs
@@ -27,6 +27,10 @@ pub enum Error {
     UnknownCollectionID,
     #[error("Access error")]
     AccessError,
+    #[error("Auth error")]
+    AuthError(String),
+    #[error("Connection closed")]
+    Closed,
     #[error("Unknown error {0}")]
     Unknown(String),
 }

--- a/src/memdx/op_auth_saslplain.rs
+++ b/src/memdx/op_auth_saslplain.rs
@@ -5,6 +5,7 @@ use crate::memdx::op_bootstrap::OpAuthEncoder;
 use crate::memdx::ops_core::OpsCore;
 use crate::memdx::pendingop::StandardPendingOp;
 use crate::memdx::request::SASLAuthRequest;
+use crate::memdx::response::SASLAuthResponse;
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SASLAuthPlainOptions {
@@ -30,7 +31,7 @@ impl OpsCore {
         dispatcher: &mut D,
         opts: SASLAuthPlainOptions,
         pipeline_cb: Option<impl (Fn()) + Send + Sync + 'static>,
-    ) -> Result<StandardPendingOp>
+    ) -> Result<StandardPendingOp<SASLAuthResponse>>
     where
         D: Dispatcher,
     {

--- a/src/memdx/ops_core.rs
+++ b/src/memdx/ops_core.rs
@@ -15,6 +15,10 @@ use crate::memdx::request::{
     GetErrorMapRequest, HelloRequest, SASLAuthRequest, SASLListMechsRequest, SASLStepRequest,
     SelectBucketRequest,
 };
+use crate::memdx::response::{
+    GetErrorMapResponse, HelloResponse, SASLAuthResponse, SASLListMechsResponse, SASLStepResponse,
+    SelectBucketResponse,
+};
 use crate::memdx::status::Status;
 
 pub struct OpsCore {}
@@ -35,7 +39,11 @@ impl OpsCore {
 }
 
 impl OpBootstrapEncoder for OpsCore {
-    async fn hello<D>(&self, dispatcher: &mut D, request: HelloRequest) -> Result<StandardPendingOp>
+    async fn hello<D>(
+        &self,
+        dispatcher: &mut D,
+        request: HelloRequest,
+    ) -> Result<StandardPendingOp<HelloResponse>>
     where
         D: Dispatcher,
     {
@@ -66,7 +74,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &mut D,
         request: GetErrorMapRequest,
-    ) -> Result<StandardPendingOp>
+    ) -> Result<StandardPendingOp<GetErrorMapResponse>>
     where
         D: Dispatcher,
     {
@@ -95,7 +103,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &mut D,
         request: SelectBucketRequest,
-    ) -> Result<StandardPendingOp>
+    ) -> Result<StandardPendingOp<SelectBucketResponse>>
     where
         D: Dispatcher,
     {
@@ -124,7 +132,7 @@ impl OpBootstrapEncoder for OpsCore {
         &self,
         dispatcher: &mut D,
         _request: SASLListMechsRequest,
-    ) -> Result<StandardPendingOp>
+    ) -> Result<StandardPendingOp<SASLListMechsResponse>>
     where
         D: Dispatcher,
     {
@@ -152,7 +160,7 @@ impl OpAuthEncoder for OpsCore {
         &self,
         dispatcher: &mut D,
         request: SASLAuthRequest,
-    ) -> Result<StandardPendingOp>
+    ) -> Result<StandardPendingOp<SASLAuthResponse>>
     where
         D: Dispatcher,
     {
@@ -185,7 +193,7 @@ impl OpAuthEncoder for OpsCore {
         &self,
         dispatcher: &mut D,
         request: SASLStepRequest,
-    ) -> Result<StandardPendingOp>
+    ) -> Result<StandardPendingOp<SASLStepResponse>>
     where
         D: Dispatcher,
     {

--- a/src/memdx/ops_crud.rs
+++ b/src/memdx/ops_crud.rs
@@ -14,6 +14,7 @@ use crate::memdx::ops_core::OpsCore;
 use crate::memdx::packet::{RequestPacket, ResponsePacket};
 use crate::memdx::pendingop::StandardPendingOp;
 use crate::memdx::request::{GetRequest, SetRequest};
+use crate::memdx::response::{GetResponse, SetResponse};
 use crate::memdx::status::Status;
 
 #[derive(Debug)]
@@ -25,7 +26,11 @@ pub struct OpsCrud {
 }
 
 impl OpsCrud {
-    pub async fn set<D>(&self, dispatcher: &mut D, request: SetRequest) -> Result<StandardPendingOp>
+    pub async fn set<D>(
+        &self,
+        dispatcher: &mut D,
+        request: SetRequest,
+    ) -> Result<StandardPendingOp<SetResponse>>
     where
         D: Dispatcher,
     {
@@ -67,7 +72,11 @@ impl OpsCrud {
 
         Ok(StandardPendingOp::new(pending_op))
     }
-    pub async fn get<D>(&self, dispatcher: &mut D, request: GetRequest) -> Result<StandardPendingOp>
+    pub async fn get<D>(
+        &self,
+        dispatcher: &mut D,
+        request: GetRequest,
+    ) -> Result<StandardPendingOp<GetResponse>>
     where
         D: Dispatcher,
     {

--- a/src/memdx/sync_helpers.rs
+++ b/src/memdx/sync_helpers.rs
@@ -7,9 +7,9 @@ use crate::memdx::response::TryFromClientResponse;
 pub async fn sync_unary_call<RespT, Fut>(fut: Fut) -> Result<RespT>
 where
     RespT: TryFromClientResponse,
-    Fut: Future<Output = Result<StandardPendingOp>>,
+    Fut: Future<Output = Result<StandardPendingOp<RespT>>>,
 {
     let mut op = fut.await?;
 
-    op.recv::<RespT>().await
+    op.recv().await
 }


### PR DESCRIPTION
Motivation
-----------
At present the type of the result returned by standard pending op recv is specified at the point of recv. Whatever
creates the op should specify the type of the result as it already knows what the type should be. This means that the creator can control the result type and makes recv feel more ergonomic.

Changes
--------
Update standard pending op so that the result type is specified at creation rather than at recv.