### PR TITLE
Apply deadline to connect/bootstrap ops

### DIFF
--- a/sdk/couchbase-core/src/memdx/client.rs
+++ b/sdk/couchbase-core/src/memdx/client.rs
@@ -271,16 +271,23 @@ mod tests {
     async fn roundtrip_a_request() {
         let _ = env_logger::try_init();
 
-        let conn = Connection::connect("192.168.107.136", 11210, ConnectOptions::default())
-            .await
-            .expect("Could not connect");
+        let instant = Instant::now().add(Duration::new(7, 0));
+
+        let conn = Connection::connect(
+            "192.168.107.128",
+            11210,
+            ConnectOptions {
+                tls_config: None,
+                deadline: instant,
+            },
+        )
+        .await
+        .expect("Could not connect");
 
         let mut client = Client::new(conn);
 
         let username = "Administrator".to_string();
         let password = "password".to_string();
-
-        let instant = Instant::now().add(Duration::new(7, 0));
 
         let bootstrap_result = OpBootstrap::bootstrap(
             OpsCore {},

--- a/sdk/couchbase-core/src/memdx/error.rs
+++ b/sdk/couchbase-core/src/memdx/error.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter};
 use std::io;
 
+use tokio::time::error::Elapsed;
+
 use crate::scram::ScramError;
 
 #[derive(thiserror::Error, Debug, Eq, PartialEq)]
@@ -72,5 +74,11 @@ impl From<io::Error> for Error {
 impl From<ScramError> for Error {
     fn from(value: ScramError) -> Self {
         Self::Auth(value.to_string())
+    }
+}
+
+impl From<Elapsed> for Error {
+    fn from(_value: Elapsed) -> Self {
+        Self::Cancelled(CancellationErrorKind::Timeout)
     }
 }


### PR DESCRIPTION
Motivation
----------
Bootstrap is only partially pipelined and is, in effect, a synchronous process. We do not return a pending op from it. This means that a higher up component cannot cancel any active requests so we should apply the deadline to individual ops and connecting.

Changes
--------
Apply deadline to connect.
Rework bootstrap a bit so that only one operation is ever active at once and apply deadline to each.